### PR TITLE
Ensure decimal has max len of 3

### DIFF
--- a/src/code/Converters/SbvConverter.php
+++ b/src/code/Converters/SbvConverter.php
@@ -86,7 +86,7 @@ class SbvConverter implements ConverterContract {
     {
         $parts = explode('.', $internal_time); // 1.23
         $whole = $parts[0]; // 1
-        $decimal = isset($parts[1]) ? $parts[1] : 0; // 23
+        $decimal = isset($parts[1]) ? substr($parts[1], 0, 3) : 0; // 23
 
         $srt_time = gmdate("0:i:s", floor($whole)) . '.' . str_pad($decimal, 3, '0', STR_PAD_RIGHT);
 

--- a/src/code/Converters/SrtConverter.php
+++ b/src/code/Converters/SrtConverter.php
@@ -88,7 +88,7 @@ class SrtConverter implements ConverterContract {
     {
         $parts = explode('.', $internal_time); // 1.23
         $whole = $parts[0]; // 1
-        $decimal = isset($parts[1]) ? $parts[1] : 0; // 23
+        $decimal = isset($parts[1]) ? substr($parts[1], 0, 3) : 0; // 23
 
         $srt_time = gmdate("H:i:s", floor($whole)) . ',' . str_pad($decimal, 3, '0', STR_PAD_RIGHT);
 

--- a/src/code/Converters/SubConverter.php
+++ b/src/code/Converters/SubConverter.php
@@ -86,7 +86,7 @@ class SubConverter implements ConverterContract {
     {
         $parts = explode('.', $internal_time); // 1.23
         $whole = $parts[0]; // 1
-        $decimal = isset($parts[1]) ? $parts[1] : 0; // 23
+        $decimal = isset($parts[1]) ? substr($parts[1], 0, 3) : 0; // 23
 
         $srt_time = gmdate("00:i:s", floor($whole)) . '.' . str_pad($decimal, 2, '0', STR_PAD_RIGHT);
 

--- a/src/code/Converters/VttConverter.php
+++ b/src/code/Converters/VttConverter.php
@@ -69,7 +69,7 @@ class VttConverter implements ConverterContract {
     {
         $parts = explode('.', $internal_time); // 1.23
         $whole = $parts[0]; // 1
-        $decimal = isset($parts[1]) ? $parts[1] : 0; // 23
+        $decimal = isset($parts[1]) ? substr($parts[1], 0, 3) : 0; // 23
 
         $srt_time = gmdate("H:i:s", floor($whole)) . '.' . str_pad($decimal, 3, '0', STR_PAD_RIGHT);
 


### PR DESCRIPTION
This PR avoids producing timecodes like `00:00:02.5599999999999`, which most video players don't understand. This has happened to me when using the `shiftTime()` method.