### PR TITLE
Support all WebVTT signatures

### DIFF
--- a/src/code/Converters/VttConverter.php
+++ b/src/code/Converters/VttConverter.php
@@ -9,7 +9,7 @@ class VttConverter implements ConverterContract {
         $blocks = explode("\n\n", trim($file_content)); // each block contains: start and end times + text
 
         foreach ($blocks as $block) {
-            if (trim($block) == 'WEBVTT') {
+            if(preg_match('/^WEBVTT.{0,}/', $block, $matches)) {
                 continue;
             }
             


### PR DESCRIPTION
Here is one of our chapter files, which passes validation, but fails to be parsed properly: http://ads.thisoldhouse.com/chaptest/TOH3021_chapters.vtt

It just reads the first line as an empty block.

According to the standard:

https://www.w3.org/TR/webvtt1/#file-structure
> The string "WEBVTT".
Optionally, either a U+0020 SPACE character or a U+0009 CHARACTER TABULATION (tab) character followed by any number of characters that are not U+000A LINE FEED (LF) or U+000D CARRIAGE RETURN (CR) characters.

This commit will now make it ignore a block if it contains zero or more characters on the line starting with WEBVTT.