### PR TITLE
fix #18

### DIFF
--- a/src/code/Converters/VttConverter.php
+++ b/src/code/Converters/VttConverter.php
@@ -56,6 +56,9 @@ class VttConverter implements ConverterContract {
     protected static function vttTimeToInternal($vtt_time)
     {
         $parts = explode('.', $vtt_time);
+        
+        // parts[0] could be mm:ss or hh:mm:ss format -> always use hh:mm:ss
+        $parts[0] = substr_count($parts[0], ':') == 2 ? $parts[0] : $parts[0] = '00:'.$parts[0];
 
         $only_seconds = strtotime("1970-01-01 {$parts[0]} UTC");
         $milliseconds = (float)('0.' . $parts[1]);

--- a/src/code/Converters/VttConverter.php
+++ b/src/code/Converters/VttConverter.php
@@ -58,7 +58,7 @@ class VttConverter implements ConverterContract {
         $parts = explode('.', $vtt_time);
         
         // parts[0] could be mm:ss or hh:mm:ss format -> always use hh:mm:ss
-        $parts[0] = substr_count($parts[0], ':') == 2 ? $parts[0] : $parts[0] = '00:'.$parts[0];
+        $parts[0] = substr_count($parts[0], ':') == 2 ? $parts[0] : '00:'.$parts[0];
 
         $only_seconds = strtotime("1970-01-01 {$parts[0]} UTC");
         $milliseconds = (float)('0.' . $parts[1]);


### PR DESCRIPTION
webvtt -> internal always use `hh:mm:ss`