### PR TITLE
support double new lines between blocks (WEBVTT)

### DIFF
--- a/src/code/Converters/VttConverter.php
+++ b/src/code/Converters/VttConverter.php
@@ -12,14 +12,21 @@ class VttConverter implements ConverterContract {
             if(preg_match('/^WEBVTT.{0,}/', $block, $matches)) {
                 continue;
             }
-            
+
             $lines = explode("\n", $block); // separate all block lines
-            
+
+            if ($lines[0] == '') {
+                // support double new lines between blocks
+                // (not in webvtt specs - see issues #15 and #17)
+                unset($lines[0]); 
+                $lines = array_values($lines);
+            }
+
             if (strpos($lines[0], '-->') === false) { // first line not containing '-->', must be cue id
                 unset($lines[0]); // not supporting cue id
                 $lines = array_values($lines);
             }
-            
+
             $times = explode(' --> ', $lines[0]);
 
             $lines_array = array_map(static::fixLine(), array_slice($lines, 1)); // get all the remaining lines from block (if multiple lines of text)


### PR DESCRIPTION
follow up #17 

we could support this:

```webvtt
WEBVTT

1
00:00:19.671 --> 00:00:23.292
Hello! I'm "Faker" Lee Sang-hyeok,
the SKT T1 mid laner.

2
00:00:23.292 --> 00:00:28.898


3
00:00:28.898 --> 00:00:33.943
Today I'm gonna give you some advices
about how to play the Mid via Naver.
```

But not this:
```webvtt
WEBVTT

1
00:00:19.671 --> 00:00:23.292
Hello! I'm "Faker" Lee Sang-hyeok,
the SKT T1 mid laner.

2
00:00:23.292 --> 00:00:28.898






3
00:00:28.898 --> 00:00:33.943
Today I'm gonna give you some advices
about how to play the Mid via Naver.
```

the maximum stray away from webvtt specs is double new lines