### PR TITLE
Fix srt conversion error when a block has no text

### DIFF
--- a/src/code/Converters/SrtConverter.php
+++ b/src/code/Converters/SrtConverter.php
@@ -15,6 +15,12 @@ class SrtConverter implements ConverterContract {
         $blocks = explode("\n\n", trim($file_content)); // each block contains: start and end times + text
         foreach ($blocks as $block) {
             $lines = explode("\n", $block); // separate all block lines
+            
+            if (empty($lines[0]) && $lines[0] != "0") { // first line empty, should be index
+                unset($lines[0]); // not supporting cue id
+                $lines = array_values($lines);
+            }
+            
             $times = explode(' --> ', $lines[1]); // one the second line there is start and end times
 
             $internal_format[] = [

--- a/src/code/Converters/SrtConverter.php
+++ b/src/code/Converters/SrtConverter.php
@@ -16,6 +16,11 @@ class SrtConverter implements ConverterContract {
         foreach ($blocks as $block) {
             $lines = explode("\n", $block); // separate all block lines
             
+            // No text is available in the block
+            if(!isset($lines[2])){
+                $lines[2] = ''; // Add an empty line, so the internal format is consitent
+            }
+            
             if (empty($lines[0]) && $lines[0] != "0") { // first line empty, should be index
                 unset($lines[0]); // not supporting cue id
                 $lines = array_values($lines);

--- a/tests/formats/SrtTest.php
+++ b/tests/formats/SrtTest.php
@@ -35,6 +35,41 @@ class SrtTest extends TestCase {
 
         $this->assertEquals(self::fileContent(), $actual_file_content);
     }
+    
+        public function testStringToInternalFormatWithMissingText()
+    {
+        $content = <<< TEXT
+0
+00:00:00,010 --> 00:00:07,777
+
+
+1
+00:00:03,371 --> 00:00:07,406
+For 13 years, the<i> cassini</i> spacecraft explored
+
+2
+00:00:07,408 --> 00:00:12,845
+astounding worlds ... saturn and its moons.
+
+3
+00:00:38,865 --> 00:00:40,822
+Lorem Ispum.
+Lorem ipsum dolor sit amet
+TEXT;
+
+        $actual_internal_format = Subtitles::load($content, $this->format)->getInternalFormat();
+
+        $expected = (new Subtitles())
+            ->add(00.010, 7.777, '')
+            ->add(3.371, 7.406, ['For 13 years, the<i> cassini</i> spacecraft explored'])
+            ->add(7.408, 12.845, ['astounding worlds ... saturn and its moons.'])
+            ->add(38.865, 40.822, ['Lorem Ispum.', 'Lorem ipsum dolor sit amet'])
+            ->getInternalFormat();
+        $actual = $actual_internal_format;
+
+        $this->assertInternalFormatsEqual($expected, $actual);
+    }
+
 
     // ---------------------------------- private ----------------------------------------------------------------------
 


### PR DESCRIPTION
If the block only contains 2 lines, e.g. no text is available, the next block will have an parsing issue. It suspects other indexes then available since position 0 has an empty entry. 
This will check this case and fixes the indexes if thats the case.