### PR TITLE
fix: remove fixLine (keep original content)

### DIFF
--- a/src/Code/Converters/VttConverter.php
+++ b/src/Code/Converters/VttConverter.php
@@ -15,12 +15,11 @@ class VttConverter implements ConverterContract
         $internal_format = [];
         foreach ($matches as $match) {
             $lines = explode("\n", $match[3]);
-            $lines_array = array_map(static::fixLine(), $lines);
 
             $internal_format[] = [
                 'start' => static::vttTimeToInternal($match[1]),
                 'end' => static::vttTimeToInternal($match[2]),
-                'lines' => $lines_array,
+                'lines' => $lines,
             ];
         }
 
@@ -72,21 +71,5 @@ class VttConverter implements ConverterContract
         $srt_time = gmdate("H:i:s", floor($whole)) . '.' . str_pad($decimal, 3, '0', STR_PAD_RIGHT);
 
         return $srt_time;
-    }
-
-    protected static function fixLine()
-    {
-        return function($line) {
-            // speaker
-            if (substr($line, 0, 3) == '<v ') {
-                $line = substr($line, 3);
-                $line = str_replace('>', ' ', $line);
-            }
-
-            // html
-            $line = strip_tags($line);
-
-            return $line;
-        };
     }
 }

--- a/tests/formats/VttTest.php
+++ b/tests/formats/VttTest.php
@@ -41,20 +41,6 @@ class VttTest extends TestCase {
         $this->assertStringEqualsStringIgnoringLineEndings($expected, $actual);
     }
 
-    public function testFileToInternalFormat()
-    {
-        $vtt_path = './tests/files/vtt_with_name.vtt';
-        $expected_internal_format = [[
-            'start' => 9,
-            'end' => 11,
-            'lines' => ['Roger Bingham We are in New York City'],
-        ]];
-
-        $actual_internal_format = Subtitles::loadFromFile($vtt_path)->getInternalFormat();
-
-        $this->assertInternalFormatsEqual($expected_internal_format, $actual_internal_format);
-    }
-
     public function testConvertToInternalFormatWhenFileContainsNumbers() // numbers are optional in webvtt format
     {
         $input_vtt_file_content = <<< TEXT
@@ -129,18 +115,6 @@ TEXT;
 
         $expected = (new Subtitles())
             ->add(0, 10, 'Hello world.')
-            ->getInternalFormat();
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    public function testParsesFileWithHtml()
-    {
-        $given = file_get_contents('./tests/files/vtt_with_html.vtt');
-        $actual = (new Subtitles())->loadFromString($given, 'vtt')->getInternalFormat();
-
-        $expected = (new Subtitles())
-            ->add(0.0, 10.0, 'Sur les playground, ici à Montpellier')
             ->getInternalFormat();
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
Hi @mantas-done, thanks for this repo!

I have a few questions about `fixLine`.

Some of use make use heavily of `internal format` and custom html tag (https://www.w3.org/TR/webvtt1/ and maybe even some application specific tag), but currently `fixLine` will alter subtitle content _before_ us have any chance to interact with it.

And the second point is `fixLine` change content in undesireable way, for example https://github.com/mantas-done/subtitles/blob/master/tests/files/vtt_with_name.vtt:
```
WEBVTT

00:00:09.000 --> 00:00:11.000
<v Roger Bingham>We are in New York City
```

Some of use do write custom html displayer for subtitle on browser. That line maybe format into:

```
Roger Bingham We are in New York City

Roger Bingham: We are in New York City

(Roger Bingham) We are in New York City

Roger Bingham - We are in New York City
```

So changing content for user is undesireable.

I have a proposal to remove `fixLine` and let user deal with it OR maybe move fixLine to when generate content from internal format (by give us a change to interact with it first) - but I think let user deal with their own format would be the best way?