### PR TITLE
fix *.scc files last subtitle end time when file has no ending lines

### DIFF
--- a/src/Code/Converters/SccConverter.php
+++ b/src/Code/Converters/SccConverter.php
@@ -34,7 +34,7 @@ class SccConverter implements ConverterContract
 
         $internal_format = [];
         $i = 0;
-        foreach ($parsed as $row) {
+        foreach ($parsed as $j => $row) {
             if (!empty($row['lines'])) {
                 if ($i !== 0 && !isset($internal_format[$i - 1]['end'])) {
                     $internal_format[$i - 1]['end'] = $row['time'];
@@ -43,6 +43,10 @@ class SccConverter implements ConverterContract
                     'start' => $row['time'],
                     'lines' => $row['lines'],
                 ];
+                // If there are no further subtitles or EOC codes present, set the end time as the start time plus 1 sec.
+                if (!isset($parsed[$j + 1])) {
+                    $internal_format[$i]['end'] = $internal_format[$i]['start'] + 1;
+                }
                 $i++;
             } elseif (isset($internal_format[$i - 1])) {
                 $internal_format[$i - 1]['end'] = $row['time'];

--- a/tests/formats/SccTest.php
+++ b/tests/formats/SccTest.php
@@ -117,4 +117,19 @@ class SccTest extends TestCase {
         $this->assertInternalFormatsEqual($expected, $actual);
 
     }
+
+    public function testLastSubtitleEndTimeCorrection()
+    {
+        $string = "Scenarist_SCC V1.0
+
+00:00:02:00\t942c 942c
+
+00:00:04:00\t94ae 94ae 9420 9420 9476 9476 97a1 97a1 c8e5 ecec ef80 942f 942f
+
+";
+        $subtitle_set = (new Subtitles())->loadFromString($string)->getInternalFormat();
+        $last_subtitle = end($subtitle_set);
+
+        $this->assertEquals($last_subtitle['end'], $last_subtitle['start'] + 1);
+    }
 }


### PR DESCRIPTION
Some *.scc files might not have ending lines to determine the length of the last subtitle. In such cases, the length will be set as the start time plus 1 second.