### PR TITLE
Added vtt cue settings to internal format

### DIFF
--- a/src/Subtitles.php
+++ b/src/Subtitles.php
@@ -65,16 +65,21 @@ class Subtitles
         return $this;
     }
 
-    public function add($start, $end, $text)
+    public function add($start, $end, $text, $settings = [])
     {
         // @TODO validation
         // @TODO check subtitles to not overlap
-        $this->internal_format[] = [
+        $internal_format = [
             'start' => $start,
             'end' => $end,
             'lines' => is_array($text) ? $text : [$text],
         ];
 
+        if (isset($settings['vtt_cue_settings']) && $settings['vtt_cue_settings']) {
+            $internal_format['vtt_cue_settings'] = $settings['vtt_cue_settings'];
+        }
+
+        $this->internal_format[] = $internal_format;
         $this->sortInternalFormat();
 
         return $this;

--- a/tests/formats/VttTest.php
+++ b/tests/formats/VttTest.php
@@ -129,7 +129,7 @@ TEXT;
         $actual = (new Subtitles())->loadFromString($given)->getInternalFormat();
 
         $expected = (new Subtitles())
-            ->add(0, 10, 'Hello world.')
+            ->add(0, 10, 'Hello world.', ['vtt_cue_settings' => 'position:50% line:15% align:middle'])
             ->getInternalFormat();
 
         $this->assertEquals($expected, $actual);


### PR DESCRIPTION
This PR is related to https://github.com/mantas-done/subtitles/issues/64

It keeps inline the vtt cue settings in internal_format as $internal_format['vtt_cue_settings'].

when the vtt is created, it checks for $internal_format['vtt_cue_settings'] and attaches it to the end of the vtt time line.

To pass tests and keep the code consistent, there should be additional parameter passed to add() for the vtt cue settings.
like ` ->add(0, 10, 'Hello world.', ['vtt_cue_settings' => 'position:50% line:15% align:middle'])`
-i used an array which makes it possible for passing extra settings as the 4th param in the future -